### PR TITLE
fix: tc-699 terraform pull request commenter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,8 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Deploy Pull Request)
       if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
-      uses: GetTerminus/terraform-pr-commenter@v2
+      uses: robburger/terraform-pr-commenter@v1
+      # uses: GetTerminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
@@ -214,7 +215,8 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Destroy Pull Request)
       if:  ${{ inputs.plan_mode != 'deploy' && github.event_name == 'pull_request' }}
-      uses: GetTerminus/terraform-pr-commenter@v2
+      uses: robburger/terraform-pr-commenter@v1
+      # uses: GetTerminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,7 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Deploy Pull Request)
       if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
-      uses: sheeeng/terraform-pull-request-commenter@v1
+      uses: sheeeng/terraform-pull-request-commenter@v1.6.0
       # uses: robburger/terraform-pr-commenter@v1
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
@@ -214,7 +214,7 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Destroy Pull Request)
       if:  ${{ inputs.plan_mode != 'deploy' && github.event_name == 'pull_request' }}
-      uses: sheeeng/terraform-pull-request-commenter@v1
+      uses: sheeeng/terraform-pull-request-commenter@v1.6.0
       # uses: robburger/terraform-pr-commenter@v1
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,8 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Deploy Pull Request)
       if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
-      uses: robburger/terraform-pr-commenter@v1
+      uses: sheeeng/terraform-pull-request-commenter@v1.6.0
+      # uses: robburger/terraform-pr-commenter@v1
       # uses: GetTerminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,7 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Deploy Pull Request)
       if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
-      uses: getterminus/terraform-pr-commenter@v2
+      uses: GetTerminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
@@ -213,7 +213,7 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Destroy Pull Request)
       if:  ${{ inputs.plan_mode != 'deploy' && github.event_name == 'pull_request' }}
-      uses: getterminus/terraform-pr-commenter@v2
+      uses: GetTerminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -202,7 +202,7 @@ runs:
         commenter_type: plan
         commenter_input: ${{ format('{0}{1}', steps.deploy_plan.outputs.stdout, steps.deploy_plan.outputs.stderr) }}
         commenter_exitcode: ${{ steps.deploy_plan.outputs.exitcode }}
-        terraform_version: ${{ inputs.terraform_version }}
+        # terraform_version: ${{ inputs.terraform_version }}
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Destroy)
       if: ${{ inputs.plan_mode != 'deploy' }}
@@ -216,7 +216,8 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Destroy Pull Request)
       if:  ${{ inputs.plan_mode != 'deploy' && github.event_name == 'pull_request' }}
-      uses: robburger/terraform-pr-commenter@v1
+      uses: sheeeng/terraform-pull-request-commenter@v1.6.0
+      # uses: robburger/terraform-pr-commenter@v1
       # uses: GetTerminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
@@ -224,7 +225,7 @@ runs:
         commenter_type: plan
         commenter_input: ${{ format('{0}{1}', steps.destroy_plan.outputs.stdout, steps.destroy_plan.outputs.stderr) }}
         commenter_exitcode: ${{ steps.destroy_plan.outputs.exitcode }}
-        terraform_version: ${{ inputs.terraform_version }}
+        # terraform_version: ${{ inputs.terraform_version }}
     # ------------------------------------------------------------------------
     - name: Remove Terraform Variable Definitions File
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -200,6 +200,7 @@ runs:
         commenter_type: plan
         commenter_input: ${{ format('{0}{1}', steps.deploy_plan.outputs.stdout, steps.deploy_plan.outputs.stderr) }}
         commenter_exitcode: ${{ steps.deploy_plan.outputs.exitcode }}
+        terraform_version: ${{ inputs.terraform_version }}
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Destroy)
       if: ${{ inputs.plan_mode != 'deploy' }}
@@ -220,6 +221,7 @@ runs:
         commenter_type: plan
         commenter_input: ${{ format('{0}{1}', steps.destroy_plan.outputs.stdout, steps.destroy_plan.outputs.stderr) }}
         commenter_exitcode: ${{ steps.destroy_plan.outputs.exitcode }}
+        terraform_version: ${{ inputs.terraform_version }}
     # ------------------------------------------------------------------------
     - name: Remove Terraform Variable Definitions File
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -193,16 +193,14 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Deploy Pull Request)
       if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
-      uses: sheeeng/terraform-pull-request-commenter@v1.6.0
+      uses: sheeeng/terraform-pull-request-commenter@v1
       # uses: robburger/terraform-pr-commenter@v1
-      # uses: GetTerminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
         commenter_type: plan
         commenter_input: ${{ format('{0}{1}', steps.deploy_plan.outputs.stdout, steps.deploy_plan.outputs.stderr) }}
         commenter_exitcode: ${{ steps.deploy_plan.outputs.exitcode }}
-        # terraform_version: ${{ inputs.terraform_version }}
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Destroy)
       if: ${{ inputs.plan_mode != 'deploy' }}
@@ -216,16 +214,14 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Destroy Pull Request)
       if:  ${{ inputs.plan_mode != 'deploy' && github.event_name == 'pull_request' }}
-      uses: sheeeng/terraform-pull-request-commenter@v1.6.0
+      uses: sheeeng/terraform-pull-request-commenter@v1
       # uses: robburger/terraform-pr-commenter@v1
-      # uses: GetTerminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
         commenter_type: plan
         commenter_input: ${{ format('{0}{1}', steps.destroy_plan.outputs.stdout, steps.destroy_plan.outputs.stderr) }}
         commenter_exitcode: ${{ steps.destroy_plan.outputs.exitcode }}
-        # terraform_version: ${{ inputs.terraform_version }}
     # ------------------------------------------------------------------------
     - name: Remove Terraform Variable Definitions File
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,7 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Deploy Pull Request)
       if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
-      uses: robburger/terraform-pr-commenter@v1
+      uses: getterminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
@@ -213,7 +213,7 @@ runs:
     # ------------------------------------------------------------------------
     - name: Terraform Plan (Destroy Pull Request)
       if:  ${{ inputs.plan_mode != 'deploy' && github.event_name == 'pull_request' }}
-      uses: robburger/terraform-pr-commenter@v1
+      uses: getterminus/terraform-pr-commenter@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:


### PR DESCRIPTION
- Disable `robburger/terraform-pr-commenter@v1` GitHub Action as this project is no longer active at the time of writing.
- Use `sheeeng/terraform-pull-request-commenter@v1.6.0`, forked from `robburger/terraform-pr-commenter@v1` project with updated fixes.